### PR TITLE
Enable Android packaging via Capacitor

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,27 +1,27 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Header } from './components/Header';
-import { ZodiacSelector } from './components/ZodiacSelector';
-import { HoroscopeDisplay } from './components/HoroscopeDisplay';
-import { AuthModal } from './components/AuthModal';
-import { Subscription } from './components/Subscription';
-import { getDailyHoroscope } from './services/geminiService';
+import { Header } from './Header';
+import { ZodiacSelector } from './ZodiacSelector';
+import { HoroscopeDisplay } from './HoroscopeDisplay';
+import { AuthModal } from './AuthModal';
+import { Subscription } from './Subscription';
+import { getDailyHoroscope } from './geminiService';
 import { ZODIAC_SIGNS } from './constants';
 import type { ZodiacSign, AuthMode, UserData, View } from './types';
-import { useLanguage } from './contexts/LanguageContext';
-import { HoroscopeFinder } from './components/HoroscopeFinder';
-import { PersonalityTestView } from './components/PersonalityTestView';
-import { ImprovementTopicView } from './components/ImprovementTopicView';
-import { getUserData, saveUserData, logoutUser, clearAllUserData } from './services/userDataService';
-import { BottomNavBar } from './components/BottomNavBar';
-import { GrowthView } from './components/GrowthView';
-import { ProfileView } from './components/ProfileView';
-import { DreamJournalView } from './components/DreamJournalView';
-import { VerifyAccountView } from './components/VerifyAccountView';
-import { SettingsView } from './components/SettingsView';
-import { soundService } from './services/soundService';
-import { notificationService } from './services/notificationService';
-import { InstallPrompt } from './components/InstallPrompt';
+import { useLanguage } from './LanguageContext';
+import { HoroscopeFinder } from './HoroscopeFinder';
+import { PersonalityTestView } from './PersonalityTestView';
+import { ImprovementTopicView } from './ImprovementTopicView';
+import { getUserData, saveUserData, logoutUser, clearAllUserData } from './userDataService';
+import { BottomNavBar } from './BottomNavBar';
+import { GrowthView } from './GrowthView';
+import { ProfileView } from './ProfileView';
+import { DreamJournalView } from './DreamJournalView';
+import { VerifyAccountView } from './VerifyAccountView';
+import { SettingsView } from './SettingsView';
+import { soundService } from './soundService';
+import { notificationService } from './notificationService';
+import { InstallPrompt } from './InstallPrompt';
 
 export default function App() {
   const [darkMode, setDarkMode] = useState(true);

--- a/AuthModal.tsx
+++ b/AuthModal.tsx
@@ -1,8 +1,8 @@
 
 import React, { useState, useEffect } from 'react';
-import type { AuthMode } from '../types';
+import type { AuthMode } from './types';
 import { CloseIcon } from './Icons';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useLanguage } from './LanguageContext';
 
 interface AuthModalProps {
   mode: AuthMode;

--- a/BottomNavBar.tsx
+++ b/BottomNavBar.tsx
@@ -1,8 +1,8 @@
 
 import React from 'react';
 import { HomeIcon, SparklesIcon, DreamIcon, ProfileIcon } from './Icons';
-import { useLanguage } from '../contexts/LanguageContext';
-import type { View } from '../types';
+import { useLanguage } from './LanguageContext';
+import type { View } from './types';
 
 interface BottomNavBarProps {
   activePage: View['type'];

--- a/DreamJournalView.tsx
+++ b/DreamJournalView.tsx
@@ -1,8 +1,8 @@
 
 import React, { useState } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { getDreamInterpretation } from '../services/geminiService';
-import type { UserData } from '../types';
+import { useLanguage } from './LanguageContext';
+import { getDreamInterpretation } from './geminiService';
+import type { UserData } from './types';
 import { LoadingSpinner } from './Icons';
 
 interface DreamJournalViewProps {

--- a/GrowthView.tsx
+++ b/GrowthView.tsx
@@ -1,8 +1,8 @@
 
 import React from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { IMPROVEMENT_TOPICS } from '../constants';
-import type { ImprovementTopicKey, UserData, View } from '../types';
+import { useLanguage } from './LanguageContext';
+import { IMPROVEMENT_TOPICS } from './constants';
+import type { ImprovementTopicKey, UserData, View } from './types';
 
 interface GrowthViewProps {
     setView: (view: View) => void;

--- a/Header.tsx
+++ b/Header.tsx
@@ -1,8 +1,8 @@
 
 import React from 'react';
 import { ProfileIcon } from './Icons';
-import { useLanguage } from '../contexts/LanguageContext';
-import { UserData } from '../types';
+import { useLanguage } from './LanguageContext';
+import { UserData } from './types';
 
 interface HeaderProps {
   isLoggedIn: boolean;

--- a/HoroscopeDisplay.tsx
+++ b/HoroscopeDisplay.tsx
@@ -1,8 +1,8 @@
 
 import React from 'react';
-import type { ZodiacSign } from '../types';
+import type { ZodiacSign } from './types';
 import { LoadingSpinner } from './Icons';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useLanguage } from './LanguageContext';
 
 interface HoroscopeDisplayProps {
   zodiac: ZodiacSign | null;

--- a/HoroscopeFinder.tsx
+++ b/HoroscopeFinder.tsx
@@ -1,8 +1,8 @@
 
 import React, { useState } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { ZODIAC_DATES, ZODIAC_SIGNS } from '../constants';
-import type { ZodiacSign } from '../types';
+import { useLanguage } from './LanguageContext';
+import { ZODIAC_DATES, ZODIAC_SIGNS } from './constants';
+import type { ZodiacSign } from './types';
 import { CloseIcon } from './Icons';
 
 interface HoroscopeFinderProps {

--- a/ImprovementTopicView.tsx
+++ b/ImprovementTopicView.tsx
@@ -1,8 +1,8 @@
 
 import React, { useState, useEffect } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { getSelfImprovementTip } from '../services/geminiService';
-import type { ImprovementTopicKey, UserData } from '../types';
+import { useLanguage } from './LanguageContext';
+import { getSelfImprovementTip } from './geminiService';
+import type { ImprovementTopicKey, UserData } from './types';
 import { LoadingSpinner } from './Icons';
 
 interface ImprovementTopicViewProps {

--- a/InstallPrompt.tsx
+++ b/InstallPrompt.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { DownloadIcon } from './Icons';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useLanguage } from './LanguageContext';
 
 export const InstallPrompt: React.FC = () => {
     const [installPromptEvent, setInstallPromptEvent] = useState<any>(null);

--- a/LanguageContext.tsx
+++ b/LanguageContext.tsx
@@ -1,8 +1,8 @@
 
 import React, { createContext, useState, useContext, useMemo, useEffect } from 'react';
-import { translations, LANGUAGES } from '../translations';
-import type { SupportedLanguage } from '../types';
-import { getUserData } from '../services/userDataService';
+import { translations, LANGUAGES } from './translations';
+import type { SupportedLanguage } from './types';
+import { getUserData } from './userDataService';
 
 interface LanguageContextType {
   language: SupportedLanguage;

--- a/LanguageSelector.tsx
+++ b/LanguageSelector.tsx
@@ -1,8 +1,8 @@
 
 import React, { useState, useRef, useEffect } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { LANGUAGES } from '../translations';
-import type { SupportedLanguage } from '../types';
+import { useLanguage } from './LanguageContext';
+import { LANGUAGES } from './translations';
+import type { SupportedLanguage } from './types';
 import { GlobeIcon, ChevronDownIcon } from './Icons';
 
 export const LanguageSelector: React.FC = () => {

--- a/PersonalityTestView.tsx
+++ b/PersonalityTestView.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { MBTI_QUESTIONS } from '../constants';
+import { useLanguage } from './LanguageContext';
+import { MBTI_QUESTIONS } from './constants';
 
 interface PersonalityTestViewProps {
     onComplete: (mbtiType: string) => void;

--- a/ProfileView.tsx
+++ b/ProfileView.tsx
@@ -1,8 +1,8 @@
 
 import React, { useRef } from 'react';
-import type { UserData, View } from '../types';
-import { useLanguage } from '../contexts/LanguageContext';
-import { ZODIAC_SIGNS } from '../constants';
+import type { UserData, View } from './types';
+import { useLanguage } from './LanguageContext';
+import { ZODIAC_SIGNS } from './constants';
 import { LogoutIcon, UserIcon, ProfileIcon, SettingsIcon, TrashIcon } from './Icons';
 
 interface ProfileViewProps {

--- a/README.md
+++ b/README.md
@@ -11,4 +11,15 @@ This contains everything you need to run your app locally.
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
-   `npm run dev`
+  `npm run dev`
+
+## Build Android APK
+
+This project uses Capacitor to package the web app as a native Android application.
+
+1. After installing dependencies, add the Android platform once:
+   `npx cap add android`
+2. Build the web assets and sync them to the Android project:
+   `npm run build:android`
+3. Open the project in Android Studio to build or run on a device:
+   `npx cap open android`

--- a/SelfImprovement.tsx
+++ b/SelfImprovement.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import { IMPROVEMENT_TOPICS } from '../constants';
-import type { ImprovementTopicKey, UserData } from '../types';
+import { useLanguage } from './LanguageContext';
+import { IMPROVEMENT_TOPICS } from './constants';
+import type { ImprovementTopicKey, UserData } from './types';
 
 interface SelfImprovementProps {
     onTopicSelect: (topicKey: ImprovementTopicKey) => void;

--- a/SettingsView.tsx
+++ b/SettingsView.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import type { UserData, SupportedLanguage } from '../types';
-import { useLanguage } from '../contexts/LanguageContext';
+import type { UserData, SupportedLanguage } from './types';
+import { useLanguage } from './LanguageContext';
 import { LanguageSelector } from './LanguageSelector';
 import { SunIcon, MoonIcon, SoundOnIcon, SoundOffIcon, NotificationIcon } from './Icons';
 

--- a/Subscription.tsx
+++ b/Subscription.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useLanguage } from './LanguageContext';
 
 export const Subscription: React.FC = () => {
     const [email, setEmail] = useState('');

--- a/VerifyAccountView.tsx
+++ b/VerifyAccountView.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
+import { useLanguage } from './LanguageContext';
 import { EmailIcon } from './Icons';
 
 interface VerifyAccountViewProps {

--- a/ZodiacSelector.tsx
+++ b/ZodiacSelector.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import type { ZodiacSign } from '../types';
-import { useLanguage } from '../contexts/LanguageContext';
+import type { ZodiacSign } from './types';
+import { useLanguage } from './LanguageContext';
 
 interface ZodiacSelectorProps {
   zodiacs: ZodiacSign[];

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,10 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.horoscopeapp',
+  appName: 'horoscope-app',
+  webDir: 'dist',
+  bundledWebRuntime: false,
+};
+
+export default config;

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,6 @@
 
 import type { ZodiacSign, MBTIQuestion, ImprovementTopicKey } from './types';
-import { AriesIcon, TaurusIcon, GeminiIcon, CancerIcon, LeoIcon, VirgoIcon, LibraIcon, ScorpioIcon, SagittariusIcon, CapricornIcon, AquariusIcon, PiscesIcon, CometIcon, OrbitingStarsIcon, LotusStarIcon } from './components/Icons';
+import { AriesIcon, TaurusIcon, GeminiIcon, CancerIcon, LeoIcon, VirgoIcon, LibraIcon, ScorpioIcon, SagittariusIcon, CapricornIcon, AquariusIcon, PiscesIcon, CometIcon, OrbitingStarsIcon, LotusStarIcon } from './Icons';
 
 export const ZODIAC_SIGNS: ZodiacSign[] = [
   { nameKey: 'aries', nameEn: 'Aries', Icon: AriesIcon },

--- a/geminiService.ts
+++ b/geminiService.ts
@@ -1,7 +1,7 @@
 
 import { GoogleGenAI } from "@google/genai";
-import { LANGUAGES } from '../translations';
-import type { SupportedLanguage, UserData } from '../types';
+import { LANGUAGES } from './translations';
+import type { SupportedLanguage, UserData } from './types';
 
 const API_KEY = process.env.API_KEY;
 

--- a/index.tsx
+++ b/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { LanguageProvider } from './contexts/LanguageContext';
+import { LanguageProvider } from './LanguageContext';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:android": "npm run build && npx cap sync android"
   },
   "dependencies": {
     "react-dom": "^19.1.0",
     "@google/genai": "^1.10.0",
-    "react": "^19.1.0"
+    "react": "^19.1.0",
+    "@capacitor/core": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "@capacitor/cli": "^5.0.0"
   }
 }

--- a/userDataService.ts
+++ b/userDataService.ts
@@ -1,5 +1,5 @@
 
-import type { UserData } from '../types';
+import type { UserData } from './types';
 
 const USER_DATA_KEY = 'horoscopeAppUserData';
 


### PR DESCRIPTION
## Summary
- fix module paths to match project structure
- add Capacitor config and dependencies
- document how to build an Android APK

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ba26ed148832c873afa8172c4df4c